### PR TITLE
WIP ktls: configure IO

### DIFF
--- a/tests/unit/s2n_ktls_test.c
+++ b/tests/unit/s2n_ktls_test.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_ktls.h"
+
+#include <stdlib.h>
+
+#include "api/s2n.h"
+#include "crypto/s2n_fips.h"
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_config.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_record.h"
+#include "tls/s2n_security_policies.h"
+#include "tls/s2n_tls13.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    EXPECT_SUCCESS(s2n_disable_tls13_in_test());
+
+    const struct s2n_security_policy *default_security_policy, *tls13_security_policy, *fips_security_policy;
+    EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &tls13_security_policy));
+    EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_fips", &fips_security_policy));
+    EXPECT_SUCCESS(s2n_find_security_policy_from_version("default", &default_security_policy));
+
+    char cert[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert, S2N_MAX_TEST_PEM_SIZE));
+    char key[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, key, S2N_MAX_TEST_PEM_SIZE));
+
+    /* config default kTLS mode */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_EQUAL(config->ktls_mode_requested, S2N_KTLS_MODE_DISABLED);
+        EXPECT_TRUE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_DISABLED));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_SEND));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_RECV));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_DUPLEX));
+    };
+
+    /* request config kTLS mode
+     *
+     * Requesting Duplex means the Send and Recv are also requested
+     */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
+        EXPECT_SUCCESS(s2n_config_ktls_enable(config, S2N_KTLS_MODE_SEND));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_DISABLED));
+        EXPECT_TRUE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_SEND));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_RECV));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_DUPLEX));
+
+        EXPECT_SUCCESS(s2n_config_ktls_enable(config, S2N_KTLS_MODE_RECV));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_DISABLED));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_SEND));
+        EXPECT_TRUE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_RECV));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_DUPLEX));
+
+        EXPECT_SUCCESS(s2n_config_ktls_enable(config, S2N_KTLS_MODE_DUPLEX));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_DISABLED));
+        EXPECT_TRUE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_SEND));
+        EXPECT_TRUE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_RECV));
+        EXPECT_TRUE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_DUPLEX));
+
+        EXPECT_SUCCESS(s2n_config_ktls_enable(config, S2N_KTLS_MODE_DISABLED));
+        EXPECT_TRUE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_DISABLED));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_SEND));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_RECV));
+        EXPECT_FALSE(s2n_config_is_ktls_requested(config, S2N_KTLS_MODE_DUPLEX));
+    };
+
+    /* connection default kTLS mode */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(conn, &io_pair));
+        EXPECT_TRUE(conn->managed_send_io);
+        EXPECT_TRUE(conn->managed_recv_io);
+
+        EXPECT_EQUAL(conn->ktls_mode_enabled, S2N_KTLS_MODE_DISABLED);
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DISABLED));
+        EXPECT_FALSE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_SEND));
+        EXPECT_FALSE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_RECV));
+        EXPECT_FALSE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DUPLEX));
+    };
+
+    /* enable kTLS modes
+     *
+     * Enabling TX and RX modes is additive and equals Duplex
+     */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(conn, &io_pair));
+        EXPECT_TRUE(conn->managed_send_io);
+        EXPECT_TRUE(conn->managed_recv_io);
+
+        EXPECT_EQUAL(conn->ktls_mode_enabled, S2N_KTLS_MODE_DISABLED);
+
+        EXPECT_OK(s2n_connection_mark_ktls_enabled(conn, S2N_KTLS_MODE_RECV));
+        EXPECT_FALSE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DISABLED));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_RECV));
+        EXPECT_FALSE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_SEND));
+        EXPECT_FALSE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DUPLEX));
+
+        EXPECT_OK(s2n_connection_mark_ktls_enabled(conn, S2N_KTLS_MODE_SEND));
+        EXPECT_FALSE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DISABLED));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_RECV));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_SEND));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DUPLEX));
+    };
+
+    /* enable kTLS duplex */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(conn, &io_pair));
+        EXPECT_TRUE(conn->managed_send_io);
+        EXPECT_TRUE(conn->managed_recv_io);
+
+        EXPECT_EQUAL(conn->ktls_mode_enabled, S2N_KTLS_MODE_DISABLED);
+
+        EXPECT_OK(s2n_connection_mark_ktls_enabled(conn, S2N_KTLS_MODE_DUPLEX));
+        EXPECT_FALSE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DISABLED));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_SEND));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_RECV));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DUPLEX));
+    };
+
+    /* DISALLOW kTLS disable on connection
+     *
+     * kTLS cannot be disabled once it has been enabled
+     *
+     * Note: This behavior might change if we introduce a kernel patch which
+     * support user space fallback from kTLS.
+     */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(conn, &io_pair));
+        EXPECT_TRUE(conn->managed_send_io);
+        EXPECT_TRUE(conn->managed_recv_io);
+
+        EXPECT_EQUAL(conn->ktls_mode_enabled, S2N_KTLS_MODE_DISABLED);
+
+        EXPECT_OK(s2n_connection_mark_ktls_enabled(conn, S2N_KTLS_MODE_DUPLEX));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_SEND));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_RECV));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DUPLEX));
+
+        EXPECT_OK(s2n_connection_mark_ktls_enabled(conn, S2N_KTLS_MODE_DISABLED));
+        EXPECT_FALSE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DISABLED));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_SEND));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_RECV));
+        EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DUPLEX));
+    };
+
+    END_TEST();
+}

--- a/tests/unit/s2n_ktls_test.c
+++ b/tests/unit/s2n_ktls_test.c
@@ -118,6 +118,11 @@ int main(int argc, char **argv)
         EXPECT_TRUE(conn->managed_send_io);
         EXPECT_TRUE(conn->managed_recv_io);
 
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_config_ktls_enable(config, S2N_KTLS_MODE_DUPLEX));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
         EXPECT_EQUAL(conn->ktls_mode_enabled, S2N_KTLS_MODE_DISABLED);
 
         EXPECT_OK(s2n_connection_mark_ktls_enabled(conn, S2N_KTLS_MODE_RECV));
@@ -144,6 +149,11 @@ int main(int argc, char **argv)
         EXPECT_TRUE(conn->managed_send_io);
         EXPECT_TRUE(conn->managed_recv_io);
 
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_config_ktls_enable(config, S2N_KTLS_MODE_DUPLEX));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
         EXPECT_EQUAL(conn->ktls_mode_enabled, S2N_KTLS_MODE_DISABLED);
 
         EXPECT_OK(s2n_connection_mark_ktls_enabled(conn, S2N_KTLS_MODE_DUPLEX));
@@ -156,6 +166,7 @@ int main(int argc, char **argv)
     /* DISALLOW kTLS disable on connection
      *
      * kTLS cannot be disabled once it has been enabled
+     * disabling kTLS, once enabled is not supported so confirm this returns an error
      *
      * Note: This behavior might change if we introduce a kernel patch which
      * support user space fallback from kTLS.
@@ -170,6 +181,11 @@ int main(int argc, char **argv)
         EXPECT_TRUE(conn->managed_send_io);
         EXPECT_TRUE(conn->managed_recv_io);
 
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_config_ktls_enable(config, S2N_KTLS_MODE_DUPLEX));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
         EXPECT_EQUAL(conn->ktls_mode_enabled, S2N_KTLS_MODE_DISABLED);
 
         EXPECT_OK(s2n_connection_mark_ktls_enabled(conn, S2N_KTLS_MODE_DUPLEX));
@@ -177,7 +193,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_RECV));
         EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DUPLEX));
 
-        EXPECT_OK(s2n_connection_mark_ktls_enabled(conn, S2N_KTLS_MODE_DISABLED));
+        EXPECT_ERROR(s2n_connection_mark_ktls_enabled(conn, S2N_KTLS_MODE_DISABLED));
         EXPECT_FALSE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DISABLED));
         EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_SEND));
         EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_RECV));

--- a/tests/unit/s2n_ktls_test.c
+++ b/tests/unit/s2n_ktls_test.c
@@ -200,5 +200,17 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_connection_matches_ktls_mode(conn, S2N_KTLS_MODE_DUPLEX));
     };
 
+    {
+        EXPECT_TRUE(s2n_ktls_is_ktls_mode_send(S2N_KTLS_MODE_SEND));
+        EXPECT_FALSE(s2n_ktls_is_ktls_mode_send(S2N_KTLS_MODE_RECV));
+        EXPECT_TRUE(s2n_ktls_is_ktls_mode_send(S2N_KTLS_MODE_DUPLEX));
+        EXPECT_FALSE(s2n_ktls_is_ktls_mode_send(S2N_KTLS_MODE_DISABLED));
+
+        EXPECT_FALSE(s2n_ktls_is_ktls_mode_recv(S2N_KTLS_MODE_SEND));
+        EXPECT_TRUE(s2n_ktls_is_ktls_mode_recv(S2N_KTLS_MODE_RECV));
+        EXPECT_TRUE(s2n_ktls_is_ktls_mode_recv(S2N_KTLS_MODE_DUPLEX));
+        EXPECT_FALSE(s2n_ktls_is_ktls_mode_recv(S2N_KTLS_MODE_DISABLED));
+    }
+
     END_TEST();
 }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+#include "tls/s2n_config.h"
+
 #include <strings.h>
 #include <time.h>
 
@@ -22,6 +24,7 @@
 #include "error/s2n_errno.h"
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_internal.h"
+#include "tls/s2n_ktls.h"
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_tls13.h"
 #include "utils/s2n_blob.h"
@@ -1066,4 +1069,27 @@ int s2n_config_set_recv_multi_record(struct s2n_config *config, bool enabled)
     config->recv_multi_record = enabled;
 
     return S2N_SUCCESS;
+}
+
+/* Indicates if the connection should attempt to enable kTLS. */
+int s2n_config_ktls_enable(struct s2n_config *config, s2n_ktls_mode ktls_mode)
+{
+    POSIX_ENSURE_REF(config);
+
+    config->ktls_mode_requested = ktls_mode;
+    return S2N_SUCCESS;
+}
+
+/* Enabling Duplex mode means that both Send and Recv are also requested. */
+bool s2n_config_is_ktls_requested(struct s2n_config *config, s2n_ktls_mode ktls_mode)
+{
+    POSIX_ENSURE_REF(config);
+
+    if (ktls_mode == S2N_KTLS_MODE_DUPLEX) {
+        return config->ktls_mode_requested == S2N_KTLS_MODE_DUPLEX;
+    }
+    if (ktls_mode == S2N_KTLS_MODE_DISABLED) {
+        return config->ktls_mode_requested == S2N_KTLS_MODE_DISABLED;
+    }
+    return config->ktls_mode_requested & ktls_mode;
 }

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -19,6 +19,7 @@
 #include "crypto/s2n_certificate.h"
 #include "crypto/s2n_dhe.h"
 #include "tls/s2n_crl.h"
+#include "tls/s2n_ktls.h"
 #include "tls/s2n_psk.h"
 #include "tls/s2n_renegotiate.h"
 #include "tls/s2n_resume.h"
@@ -175,6 +176,11 @@ struct s2n_config {
 
     void *renegotiate_request_ctx;
     s2n_renegotiate_request_cb renegotiate_request_cb;
+
+    /* Depending on OS and configuration it is possible to use kTLS.
+     *
+     * This option indicates if connections should attempt to use kTLS. */
+    s2n_ktls_mode ktls_mode_requested;
 };
 
 S2N_CLEANUP_RESULT s2n_config_ptr_free(struct s2n_config **config);
@@ -190,3 +196,4 @@ void s2n_wipe_static_configs(void);
 extern struct s2n_cert_chain_and_key *s2n_config_get_single_default_cert(struct s2n_config *config);
 int s2n_config_get_num_default_certs(struct s2n_config *config);
 S2N_RESULT s2n_config_wall_clock(struct s2n_config *config, uint64_t *output);
+bool s2n_config_is_ktls_requested(struct s2n_config *config, s2n_ktls_mode ktls_mode);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1526,6 +1526,7 @@ S2N_RESULT s2n_connection_dynamic_free_in_buffer(struct s2n_connection *conn)
 S2N_RESULT s2n_connection_mark_ktls_enabled(struct s2n_connection *conn, s2n_ktls_mode ktls_mode)
 {
     RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_NE(ktls_mode, S2N_KTLS_MODE_DISABLED);
 
     /* kTLS I/O functionality is managed by s2n-tls. kTLS cannot be enabled
      * if the application sets custom I/O. */
@@ -1535,6 +1536,8 @@ S2N_RESULT s2n_connection_mark_ktls_enabled(struct s2n_connection *conn, s2n_ktl
     if ((ktls_mode == S2N_KTLS_MODE_RECV || ktls_mode == S2N_KTLS_MODE_DUPLEX) && !conn->managed_recv_io) {
         return S2N_RESULT_ERROR;
     }
+    /* perform sanity check. */
+    RESULT_GUARD(s2n_ktls_validate(conn, ktls_mode));
 
     conn->ktls_mode_enabled |= ktls_mode;
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -282,8 +282,8 @@ struct s2n_connection {
      */
     uint16_t max_outgoing_fragment_length;
 
-    /* The number of bytes to send before changing the record size. 
-     * If this value > 0 then dynamic TLS record size is enabled. Otherwise, the feature is disabled (default). 
+    /* The number of bytes to send before changing the record size.
+     * If this value > 0 then dynamic TLS record size is enabled. Otherwise, the feature is disabled (default).
      */
     uint32_t dynamic_record_resize_threshold;
 
@@ -385,6 +385,9 @@ struct s2n_connection {
     uint32_t server_keying_material_lifetime;
 
     struct s2n_post_handshake post_handshake;
+
+    /* Marks if kTLS has been enabled for this connection. */
+    s2n_ktls_mode ktls_mode_enabled;
 };
 
 S2N_CLEANUP_RESULT s2n_connection_ptr_free(struct s2n_connection **s2n_connection);
@@ -417,3 +420,4 @@ int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **
 int s2n_connection_get_peer_cert_chain(const struct s2n_connection *conn, struct s2n_cert_chain_and_key *cert_chain_and_key);
 uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn);
 S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *conn, uint16_t length);
+S2N_RESULT s2n_connection_mark_ktls_enabled(struct s2n_connection *conn, s2n_ktls_mode mode);

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -135,13 +135,6 @@ struct s2n_connection {
      * instead of the ALPN extension */
     unsigned npn_negotiated : 1;
 
-    /* ktls is enabled for this connection.
-     *
-     * This means that UPL has been enabled, transport keys have been set
-     * and ktls specific IO callback/context has been set.
-     */
-    /* unsigned ktls_enabled_send_io : 1; */
-    /* unsigned ktls_enabled_recv_io : 1; */
     /* Marks if kTLS has been enabled for this connection. */
     s2n_ktls_mode ktls_mode_enabled;
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -91,7 +91,9 @@ struct s2n_connection {
     unsigned write_fd_broken : 1;
 
     /* Has the user set their own I/O callbacks or is this connection using the
-     * default socket-based I/O set by s2n */
+     * default socket-based I/O set by s2n.
+     *
+     * True means that s2n has configured the I/O and is managing it. */
     unsigned managed_send_io : 1;
     unsigned managed_recv_io : 1;
 
@@ -132,6 +134,16 @@ struct s2n_connection {
     /* Indicates protocol negotiation will be done through the NPN extension
      * instead of the ALPN extension */
     unsigned npn_negotiated : 1;
+
+    /* ktls is enabled for this connection.
+     *
+     * This means that UPL has been enabled, transport keys have been set
+     * and ktls specific IO callback/context has been set.
+     */
+    /* unsigned ktls_enabled_send_io : 1; */
+    /* unsigned ktls_enabled_recv_io : 1; */
+    /* Marks if kTLS has been enabled for this connection. */
+    s2n_ktls_mode ktls_mode_enabled;
 
     /* The configuration (cert, key .. etc ) */
     struct s2n_config *config;
@@ -385,9 +397,6 @@ struct s2n_connection {
     uint32_t server_keying_material_lifetime;
 
     struct s2n_post_handshake post_handshake;
-
-    /* Marks if kTLS has been enabled for this connection. */
-    s2n_ktls_mode ktls_mode_enabled;
 };
 
 S2N_CLEANUP_RESULT s2n_connection_ptr_free(struct s2n_connection **s2n_connection);
@@ -421,3 +430,5 @@ int s2n_connection_get_peer_cert_chain(const struct s2n_connection *conn, struct
 uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn);
 S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *conn, uint16_t length);
 S2N_RESULT s2n_connection_mark_ktls_enabled(struct s2n_connection *conn, s2n_ktls_mode mode);
+S2N_RESULT s2n_connection_set_ktls_write_fd(struct s2n_connection *conn, int wfd);
+S2N_RESULT s2n_connection_set_ktls_read_fd(struct s2n_connection *conn, int rfd);

--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_ktls.h"
+
+/*
+ * TODO implement
+ */
+S2N_RESULT s2n_ktls_enable(struct s2n_connection *conn, s2n_ktls_mode mode)
+{
+    /* TODO perform managed_send_io and managed_recv_io checks */
+
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -13,15 +13,151 @@
  * permissions and limitations under the License.
  */
 
-#include "s2n_ktls.h"
+#include "tls/s2n_ktls.h"
 
-/*
- * TODO implement
- */
-S2N_RESULT s2n_ktls_enable(struct s2n_connection *conn, s2n_ktls_mode mode)
+#include <linux/tls.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+
+#include "error/s2n_errno.h"
+#include "tls/s2n_config.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_crypto.h"
+#include "utils/s2n_result.h"
+#include "utils/s2n_safety_macros.h"
+#include "utils/s2n_socket.h"
+
+#define TLS_ULP      "tls"
+#define TLS_ULP_SIZE sizeof(TLS_ULP)
+/* value declared in netinet/tcp.h */
+#define SOL_TCP 6 /* TCP level */
+
+bool s2n_ktls_is_ktls_mode_eq(s2n_ktls_mode a, s2n_ktls_mode b)
 {
-    /* TODO perform managed_send_io and managed_recv_io checks */
+    if (b == S2N_KTLS_MODE_DUPLEX) {
+        return a == S2N_KTLS_MODE_DUPLEX;
+    }
+    if (b == S2N_KTLS_MODE_DISABLED) {
+        return a == S2N_KTLS_MODE_DISABLED;
+    }
+    return a & b;
+}
+
+S2N_RESULT s2n_ktls_set_crypto_info(
+        s2n_ktls_mode ktls_mode,
+        int fd,
+        uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN],
+        uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN])
+{
+    uint8_t key[16] = { 0 };
+
+    struct tls12_crypto_info_aes_gcm_128 crypto_info;
+
+    /* AES_GCM_128 specific configuration */
+    crypto_info.info.cipher_type = TLS_CIPHER_AES_GCM_128;
+    RESULT_CHECKED_MEMCPY(crypto_info.salt, implicit_iv, TLS_CIPHER_AES_GCM_128_SALT_SIZE);
+    RESULT_CHECKED_MEMCPY(crypto_info.rec_seq, sequence_number, TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
+    RESULT_CHECKED_MEMCPY(crypto_info.key, key, TLS_CIPHER_AES_GCM_128_KEY_SIZE);
+
+    /* TLS1.2 specific configuration */
+    crypto_info.info.version = TLS_1_2_VERSION;
+    RESULT_CHECKED_MEMCPY(crypto_info.iv, implicit_iv, TLS_CIPHER_AES_GCM_128_IV_SIZE);
+
+    int tls_mode;
+    /* configure socket and enable kTLS */
+    if (s2n_ktls_is_ktls_mode_eq(ktls_mode, S2N_KTLS_MODE_RECV)) {
+        tls_mode = TLS_RX;
+    } else if (s2n_ktls_is_ktls_mode_eq(ktls_mode, S2N_KTLS_MODE_SEND)) {
+        tls_mode = TLS_RX;
+    } else {
+        /* unreachable */
+        return S2N_RESULT_ERROR;
+    }
+
+    RESULT_GUARD_POSIX(setsockopt(fd, SOL_TLS, tls_mode, &crypto_info, sizeof(crypto_info)));
 
     return S2N_RESULT_OK;
 }
 
+S2N_RESULT s2n_ktls_enable_impl(struct s2n_connection *conn, s2n_ktls_mode ktls_mode, int fd)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE(ktls_mode == S2N_KTLS_MODE_RECV || ktls_mode == S2N_KTLS_MODE_SEND, S2N_ERR_SAFETY);
+
+    /* register the tls ULP */
+    RESULT_GUARD_POSIX(setsockopt(fd, SOL_TCP, TCP_ULP, TLS_ULP, TLS_ULP_SIZE));
+
+    /* set crypto info and enable kTLS on the socket */
+    struct s2n_crypto_parameters *crypto_param;
+    if (conn->mode == S2N_SERVER) {
+        crypto_param = conn->server;
+    } else {
+        crypto_param = conn->client;
+    }
+    RESULT_GUARD(s2n_ktls_set_crypto_info(ktls_mode, fd, crypto_param->server_implicit_iv, crypto_param->server_sequence_number));
+
+    /* Note: kTLS has been enabled on the socket. Errors must be handled appropriately and
+     * are likely to be fatal. */
+
+    /* TODO configure kTLS specific I/O callback and context. */
+
+    /* mark kTLS enabled on the connection */
+    RESULT_GUARD(s2n_connection_mark_ktls_enabled(conn, ktls_mode));
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_ktls_validate(struct s2n_connection *conn, s2n_ktls_mode ktls_mode)
+{
+    RESULT_ENSURE_REF(conn);
+
+    /* TODO support TLS1.3
+     *
+     * TLS1.3 support requires sending the KeyUpdate message when the cryptographic
+     * KeyLimits are met. However, this is currently only possible by applying a
+     * kernel patch to support this functionality.
+     */
+    RESULT_ENSURE_EQ(conn->actual_protocol_version, S2N_TLS12);
+
+    /* TODO Add validation for cipher suites */
+
+    /* confirm that the application requested ktls */
+    RESULT_ENSURE(s2n_config_is_ktls_requested(conn->config, ktls_mode), S2N_ERR_SAFETY);
+
+    /* kTLS I/O functionality is managed by s2n-tls. kTLS cannot be enabled
+     * if the application sets custom I/O.
+     */
+    if (s2n_ktls_is_ktls_mode_eq(ktls_mode, S2N_KTLS_MODE_SEND) && !conn->managed_send_io) {
+        return S2N_RESULT_ERROR;
+    }
+    if (s2n_ktls_is_ktls_mode_eq(ktls_mode, S2N_KTLS_MODE_RECV) && !conn->managed_recv_io) {
+        return S2N_RESULT_ERROR;
+    }
+
+    /* confim kTLS isn't enabled already */
+    RESULT_ENSURE_EQ(s2n_connection_matches_ktls_mode(conn, ktls_mode), false);
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_ktls_enable(struct s2n_connection *conn, s2n_ktls_mode ktls_mode)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_GUARD(s2n_ktls_validate(conn, ktls_mode));
+
+    if (s2n_ktls_is_ktls_mode_eq(ktls_mode, S2N_KTLS_MODE_RECV)) {
+        /* retrieve the recv fd */
+        const struct s2n_socket_write_io_context *peer_socket_ctx = conn->recv_io_context;
+        int fd = peer_socket_ctx->fd;
+        RESULT_GUARD(s2n_ktls_enable_impl(conn, S2N_KTLS_MODE_RECV, fd));
+    }
+
+    if (s2n_ktls_is_ktls_mode_eq(ktls_mode, S2N_KTLS_MODE_SEND)) {
+        /* retrieve the send fd */
+        const struct s2n_socket_write_io_context *peer_socket_ctx = conn->send_io_context;
+        int fd = peer_socket_ctx->fd;
+        RESULT_GUARD(s2n_ktls_enable_impl(conn, S2N_KTLS_MODE_SEND, fd));
+    }
+
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -24,3 +24,4 @@ S2N_RESULT s2n_ktls_enable(struct s2n_connection *conn, s2n_ktls_mode mode)
 
     return S2N_RESULT_OK;
 }
+

--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -33,14 +33,6 @@
 /* value declared in netinet/tcp.h */
 #define SOL_TCP 6 /* TCP level */
 
-/* Depending on OS and configuration it might not be possible to enable kTLS. This
- * however is not fatal and s2n can continue to operate.
- *
- * This macro captures the non-fatal nature of a kTLS operation failing by
- * returning S2N_RESULT_OK on failure.
- */
-#define RESULT_GUARD_KTLS_OK(result) __S2N_ENSURE(s2n_result_is_ok(result), return S2N_RESULT_OK)
-
 bool s2n_ktls_is_ktls_mode_send(s2n_ktls_mode ktls_mode)
 {
     return ktls_mode & S2N_KTLS_MODE_SEND;
@@ -143,24 +135,28 @@ S2N_RESULT s2n_ktls_validate(struct s2n_connection *conn, s2n_ktls_mode ktls_mod
 S2N_RESULT s2n_ktls_enable(struct s2n_connection *conn, s2n_ktls_mode ktls_mode)
 {
     RESULT_ENSURE_REF(conn);
-    RESULT_GUARD_KTLS_OK(s2n_ktls_validate(conn, ktls_mode));
+    s2n_result_ignore(s2n_ktls_validate(conn, ktls_mode));
 
     int fd;
     if (s2n_ktls_is_ktls_mode_recv(ktls_mode)) {
         /* retrieve the recv fd */
         const struct s2n_socket_write_io_context *peer_socket_ctx = conn->recv_io_context;
         fd = peer_socket_ctx->fd;
-        RESULT_GUARD_KTLS_OK(s2n_ktls_enable_impl(conn, S2N_KTLS_MODE_RECV, fd));
+        s2n_result_ignore(s2n_ktls_enable_impl(conn, S2N_KTLS_MODE_RECV, fd));
     }
 
     if (s2n_ktls_is_ktls_mode_send(ktls_mode)) {
         /* retrieve the send fd */
         const struct s2n_socket_write_io_context *peer_socket_ctx = conn->send_io_context;
         fd = peer_socket_ctx->fd;
-        RESULT_GUARD_KTLS_OK(s2n_ktls_enable_impl(conn, S2N_KTLS_MODE_SEND, fd));
+        s2n_result_ignore(s2n_ktls_enable_impl(conn, S2N_KTLS_MODE_SEND, fd));
     }
 
-    /* Note: kTLS has been enabled on the socket. Any subsequent errors are likely to be fatal. */
+    /* Note: Depending on OS and configuration it might not be possible to enable kTLS.
+     * This is not fatal and s2n can continue to operate.
+     *
+     * However once enables, any subsequent errors should be treated as fatal.
+     */
 
     /* configure kTLS specific I/O callback and context. */
     RESULT_GUARD(s2n_connection_set_ktls_write_fd(conn, fd));

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#include "utils/s2n_result.h"
+
+/* --- unstable API ---
+ *
+ * These will eventually be moved to unstable/ktls.h once kTLS is implemented
+ */
+
+/* A set of kTLS configurations representing the combination of sending
+ * and receiving.
+ *
+ * s2n assumes specific binary representation for the following modes:
+ *
+ * S2N_KTLS_MODE_SEND | S2N_KTLS_MODE_RECV = S2N_KTLS_MODE_DUPLEX
+ * 0b01               | 0b10               = 0b11
+ */
+typedef enum {
+    /* Disable kTLS. */
+    S2N_KTLS_MODE_DISABLED = 0,
+    /* Enable kTLS for the send socket. */
+    S2N_KTLS_MODE_SEND = 1,
+    /* Enable kTLS for the recv socket. */
+    S2N_KTLS_MODE_RECV = 2,
+    /* Enable kTLS for both rx and tx socket. */
+    S2N_KTLS_MODE_DUPLEX = 3,
+} s2n_ktls_mode;
+
+int s2n_config_ktls_enable(struct s2n_config *config, s2n_ktls_mode ktls_mode);
+
+bool s2n_connection_matches_ktls_mode(struct s2n_connection *conn, s2n_ktls_mode ktls_mode);
+
+/* --- unstable API --- */
+
+S2N_RESULT s2n_ktls_enable(struct s2n_connection *conn, s2n_ktls_mode mode);

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -49,4 +49,5 @@ bool s2n_connection_matches_ktls_mode(struct s2n_connection *conn, s2n_ktls_mode
 
 /* --- unstable API --- */
 
-S2N_RESULT s2n_ktls_enable(struct s2n_connection *conn, s2n_ktls_mode mode);
+S2N_RESULT s2n_ktls_enable(struct s2n_connection *conn, s2n_ktls_mode ktls_mode);
+S2N_RESULT s2n_ktls_validate(struct s2n_connection *conn, s2n_ktls_mode ktls_mode);

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -51,3 +51,16 @@ bool s2n_connection_matches_ktls_mode(struct s2n_connection *conn, s2n_ktls_mode
 
 S2N_RESULT s2n_ktls_enable(struct s2n_connection *conn, s2n_ktls_mode ktls_mode);
 S2N_RESULT s2n_ktls_validate(struct s2n_connection *conn, s2n_ktls_mode ktls_mode);
+int s2n_ktls_write_fn(void *io_context, const uint8_t *buf, uint32_t len);
+int s2n_ktls_read_fn(void *io_context, uint8_t *buf, uint32_t len);
+
+/* The default write I/O context for communication over a ktls socket */
+struct s2n_ktls_write_io_context {
+    /* The send fd */
+    int fd;
+};
+
+struct s2n_ktls_read_io_context {
+    /* The recv fd */
+    int fd;
+};

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -227,6 +227,8 @@ static inline int s2n_record_encrypt(
 
 int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const struct iovec *in, int in_count, size_t offs, size_t to_write)
 {
+    /* TODO: handle kTLS write */
+
     struct s2n_blob iv = { 0 };
     uint8_t padding = 0;
     uint16_t block_size = 0;

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -241,6 +241,10 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
             POSIX_CHECKED_MEMCPY(conn->session_id, session_id, session_id_len);
             conn->actual_protocol_version = actual_protocol_version;
             POSIX_GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
+
+            /* TODO re-derive key and enable kTLS for TLS12 */
+            POSIX_GUARD_RESULT(s2n_ktls_enable(conn, conn->config->ktls_mode_requested));
+
             /* Erase master secret which might have been set for session resumption */
             POSIX_CHECKED_MEMSET((uint8_t *) conn->secrets.tls12.master_secret, 0, S2N_TLS_SECRET_LEN);
 

--- a/tls/s2n_tls13_key_schedule.c
+++ b/tls/s2n_tls13_key_schedule.c
@@ -128,6 +128,12 @@ static S2N_RESULT s2n_set_key(struct s2n_connection *conn, s2n_extract_secret_ty
     RESULT_GUARD_POSIX(s2n_hkdf_expand_label(&hmac, hmac_alg,
             &secret, iv_purpose, &s2n_zero_length_context, &iv));
 
+    /* TODO enable kTLS for TLS13 */
+    if (secret_type == S2N_APPLICATION_SECRET) {
+        RESULT_GUARD(s2n_ktls_enable(conn, conn->config->ktls_mode_requested));
+    }
+
+
     bool is_sending_secret = (mode == conn->mode);
     if (is_sending_secret) {
         RESULT_GUARD_POSIX(cipher->set_encryption_key(session_key, &key));


### PR DESCRIPTION
https://github.com/aws/s2n-tls/issues/3711
Depends on https://github.com/aws/s2n-tls/pull/3707

### Description of changes: 
This PR enables kTLS by configuring the socket and setting the cryptographic material. Currently we only support TLS1.2 and AES_GCM_128.

### Testing:
Add a validation around kTLS which is now run as part of existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
